### PR TITLE
Removed CAHostTimeBase.cpp from non-OSX build

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -6,12 +6,12 @@
         'src/codec.cc', 'src/bindings.cc',
         'alac/EndianPortable.c', 'alac/ALACBitUtilities.c', 'alac/ALACEncoder.cpp',
         'alac/ag_enc.c', 'alac/ag_dec.c', 'alac/dp_enc.c', 'alac/matrix_enc.c',
-        'src/aes_utils.c', 'src/base64.c', 'src/CAHostTimeBase.cpp'
+        'src/aes_utils.c', 'src/base64.c'
       ],
       'conditions': [
         ['OS=="mac"', {
           'include_dirs+': '/System/Library/Frameworks/Kernel.framework/Versions/A/Headers/sys',
-          'sources': ['src/coreaudio.cc']
+          'sources': ['src/coreaudio.cc','src/CAHostTimeBase.cpp']
         }]
       ]
     }


### PR DESCRIPTION
binding.gyp tried to compile CAHostTimeBase.cpp even if the current system was not OS X. doing so, ends up in an error.
this pull requests fixes this issue by moving the source file into the conditional OS X section.
