### PR TITLE
Fix endianness for ARM in ALAC.

### DIFF
--- a/alac/EndianPortable.c
+++ b/alac/EndianPortable.c
@@ -40,6 +40,8 @@
 #define TARGET_RT_LITTLE_ENDIAN 1
 #elif defined (TARGET_OS_WIN32)
 #define TARGET_RT_LITTLE_ENDIAN 1
+#elif defined(__arm__)
+#define TARGET_RT_LITTLE_ENDIAN 1
 #endif
 
 uint16_t Swap16NtoB(uint16_t inUInt16)


### PR DESCRIPTION
The ALAC library wasn't using little-endian for ARM, which caused #6.
