### PR TITLE
Do not send AES key to devices that do not require encryption.

### DIFF
--- a/lib/rtsp.js
+++ b/lib/rtsp.js
@@ -299,9 +299,12 @@ Client.prototype.sendNextRequest = function(di) {
       't=0 0\r\n' +
       'm=audio 0 RTP/AVP 96\r\n' +
       'a=rtpmap:96 AppleLossless\r\n' +
-      'a=fmtp:96 352 0 16 40 10 14 2 255 0 0 44100\r\n' +
-      'a=rsaaeskey:' + config.rsa_aeskey_base64 + '\r\n' +
-      'a=aesiv:' + config.iv_base64 + '\r\n';
+      'a=fmtp:96 352 0 16 40 10 14 2 255 0 0 44100\r\n';
+    if (this.requireEncryption) {
+      body +=
+        'a=rsaaeskey:' + config.rsa_aeskey_base64 + '\r\n' +
+        'a=aesiv:' + config.iv_base64 + '\r\n';
+    }
 
     request += this.makeHeadWithURL('ANNOUNCE', di);
     request +=


### PR DESCRIPTION
Update to enable streaming to the Apple TV.
