### PR TITLE
Multiple instance support and gapeless play

### DIFF
--- a/lib/device_airtunes.js
+++ b/lib/device_airtunes.js
@@ -44,7 +44,7 @@ AirTunesDevice.prototype.start = function() {
     self.doHandshake();
   });
 
-  udpServers.bind();
+  udpServers.bind(this.host);
 };
 
 AirTunesDevice.prototype.doHandshake = function() {
@@ -69,7 +69,7 @@ AirTunesDevice.prototype.doHandshake = function() {
       self.emit(err);
   });
 
-  this.rtsp.startHandshake(this.host, this.port);
+  this.rtsp.startHandshake(udpServers, this.host, this.port);
 };
 
 AirTunesDevice.prototype.relayAudio = function() {

--- a/lib/device_airtunes.js
+++ b/lib/device_airtunes.js
@@ -62,9 +62,8 @@ AirTunesDevice.prototype.doHandshake = function() {
     self.relayAudio();
   });
 
-  this.rtsp.on('end', function(err) {
+  this.rtsp.on('end', function(err, msg) {
     self.cleanup();
-
     if(err !== 'stopped')
       self.emit(err);
   });

--- a/lib/device_airtunes.js
+++ b/lib/device_airtunes.js
@@ -62,8 +62,9 @@ AirTunesDevice.prototype.doHandshake = function() {
     self.relayAudio();
   });
 
-  this.rtsp.on('end', function(err, msg) {
+  this.rtsp.on('end', function(err) {
     self.cleanup();
+
     if(err !== 'stopped')
       self.emit(err);
   });

--- a/lib/device_airtunes.js
+++ b/lib/device_airtunes.js
@@ -104,6 +104,10 @@ AirTunesDevice.prototype.cleanup = function() {
   this.removeAllListeners();
 };
 
+AirTunesDevice.prototype.reportStatus = function(){
+   this.emit('status', this.status);
+};
+
 AirTunesDevice.prototype.stop = function(cb) {
   this.rtsp.once('end', function() {
     if(cb)

--- a/lib/device_coreaudio.js
+++ b/lib/device_coreaudio.js
@@ -65,6 +65,10 @@ CoreAudioDevice.prototype.start = function(hideStatus) {
   audioOut.on('packet', this.audioCallback);
 }
 
+CoreAudioDevice.prototype.reportStatus = function(){
+   this.emit('status', this.status);
+};
+
 CoreAudioDevice.prototype.setHasAirTunes = function(hasAirTunes) {
   this.latency = hasAirTunes ?
     11025 + 2*config.sampling_rate :

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,8 +2,7 @@ var Stream = require('stream'),
     util = require('util'),
     devices = require('./devices.js'),
     circularBuffer = require('./circular_buffer.js'),
-    audioOut = require('./audio_out.js'),
-    udpServers = require('./udp_servers.js');
+    audioOut = require('./audio_out.js'); 
 
 function AirTunes() {
   var self = this;
@@ -20,7 +19,6 @@ function AirTunes() {
   });
 
   audioOut.init(devices);
-  udpServers.init(devices);
 
   circularBuffer.on('drain', function() {
     self.emit('drain');

--- a/lib/index.js
+++ b/lib/index.js
@@ -53,6 +53,10 @@ AirTunes.prototype.setTrackInfo = function(deviceKey, name, artist, album, callb
   devices.setTrackInfo(deviceKey, name, artist, album, callback);
 };
 
+AirTunes.prototype.reset = function() {
+	circularBuffer.reset();
+};
+
 AirTunes.prototype.setArtwork = function(deviceKey, art, contentType, callback) {
   devices.setArtwork(deviceKey, art, contentType, callback);
 };

--- a/lib/rtsp.js
+++ b/lib/rtsp.js
@@ -4,7 +4,6 @@ var net = require('net'),
     util = require('util'),
     fs = require('fs'),
     config = require('./config.js'),
-//    udpServers = require('./udp_servers.js'),
     audioOut = require('./audio_out.js'),
     nu = require('./num_util.js');
 

--- a/lib/rtsp.js
+++ b/lib/rtsp.js
@@ -4,7 +4,7 @@ var net = require('net'),
     util = require('util'),
     fs = require('fs'),
     config = require('./config.js'),
-    udpServers = require('./udp_servers.js'),
+//    udpServers = require('./udp_servers.js'),
     audioOut = require('./audio_out.js'),
     nu = require('./num_util.js');
 
@@ -38,17 +38,23 @@ function Client(volume, password) {
   this.artwork = null;
   this.artworkContentType = null;
   this.callback = null;
+  this.controlPort = null;
+  this.timingPort  = null;
 }
 
 util.inherits(Client, events.EventEmitter);
 
 exports.Client = Client;
 
-Client.prototype.startHandshake = function(host, port) {
+Client.prototype.startHandshake = function(udpServers, host, port) {
   var self = this;
 
   this.startTimeout();
-
+  
+  this.controlPort = udpServers.control.port;
+  this.timingPort  = udpServers.timing.port;
+  
+  
   this.socket = net.connect(port, host, function() {
     self.clearTimeout();
     self.sendNextRequest();
@@ -318,8 +324,8 @@ Client.prototype.sendNextRequest = function(di) {
     request += this.makeHeadWithURL('SETUP', di);
     request +=
       'Transport: RTP/AVP/UDP;unicast;interleaved=0-1;mode=record;' +
-      'control_port=' + udpServers.control.port + ';' +
-      'timing_port=' + udpServers.timing.port + '\r\n\r\n';
+      'control_port=' + this.controlPort + ';' +
+      'timing_port=' + this.timingPort + '\r\n\r\n';
     break;
 
   case RECORD:

--- a/lib/udp_servers.js
+++ b/lib/udp_servers.js
@@ -12,7 +12,7 @@ var UNBOUND = 0,
 
 function UDPServers() {
   events.EventEmitter.call(this);
-  
+
   this.status = UNBOUND;
 
   this.control = {

--- a/lib/udp_servers.js
+++ b/lib/udp_servers.js
@@ -12,7 +12,7 @@ var UNBOUND = 0,
 
 function UDPServers() {
   events.EventEmitter.call(this);
-
+  
   this.status = UNBOUND;
 
   this.control = {
@@ -26,12 +26,15 @@ function UDPServers() {
     port: null,
     name: 'timing'
   };
+  this.hosts = [];
 }
 
 util.inherits(UDPServers, events.EventEmitter);
 
 UDPServers.prototype.bind = function(host) {
   var self = this;
+  
+  this.hosts.push(host);
 
   switch(this.status) {
   case BOUND:
@@ -52,8 +55,8 @@ UDPServers.prototype.bind = function(host) {
 
   this.timing.socket.on('message', function(msg, rinfo) {
 	
-	// only listen and respond to self host  
-	if (rinfo.address !== host) return;
+	// only listen and respond on own hosts  
+	if (self.hosts.indexOf(rinfo.address) < 0) return;
 	
     var ts1 = msg.readUInt32BE(24);
     var ts2 = msg.readUInt32BE(28);
@@ -82,8 +85,8 @@ UDPServers.prototype.bind = function(host) {
 
   this.control.socket.on('message', function(msg, rinfo) {
 	
-	// only listen for self host 
-	if (rinfo.address !== host) return;
+	// only listen for own hosts 
+	if (self.hosts.indexOf(rinfo.address) < 0) return;
 		  
     var serverSeq = msg.readUInt16BE(2);
     var missedSeq = msg.readUInt16BE(4);

--- a/lib/udp_servers.js
+++ b/lib/udp_servers.js
@@ -30,17 +30,7 @@ function UDPServers() {
 
 util.inherits(UDPServers, events.EventEmitter);
 
-UDPServers.prototype.init = function(devices) {
-  var self = this;
-
-  devices.on('airtunes_devices', function(hasAirTunes) {
-    // open UDP servers only when we have AirTunes devices
-    if(!hasAirTunes)
-      self.close();
-  });
-};
-
-UDPServers.prototype.bind = function() {
+UDPServers.prototype.bind = function(host) {
   var self = this;
 
   switch(this.status) {
@@ -61,6 +51,10 @@ UDPServers.prototype.bind = function() {
   this.timing.socket = dgram.createSocket('udp4');
 
   this.timing.socket.on('message', function(msg, rinfo) {
+	
+	// only listen and respond to self host  
+	if (rinfo.address !== host) return;
+	
     var ts1 = msg.readUInt32BE(24);
     var ts2 = msg.readUInt32BE(28);
 
@@ -87,6 +81,10 @@ UDPServers.prototype.bind = function() {
   this.control.socket = dgram.createSocket('udp4');
 
   this.control.socket.on('message', function(msg, rinfo) {
+	
+	// only listen for self host 
+	if (rinfo.address !== host) return;
+		  
     var serverSeq = msg.readUInt16BE(2);
     var missedSeq = msg.readUInt16BE(4);
     var count = msg.readUInt16BE(6);


### PR DESCRIPTION
Support for multiple instances, each one streaming her own song to single/multiple devices.
-Filter each instance own hosts in udpServers by ip adress.
Note : fixed multiple host streaming the same song issue of first commit.

Gapeless play.
-Expose cirgularBuffer.reset() into Airtunes.reset() method
-Implement missing reportStatus method in airtune_device and coreAudio

When a device emit a "redy" event, call Airtunes.reset() and pipe the next song to airtunes.
```javascript
player.on('ready', function(){
// next song
  ffmpeg=spawn('ffmpeg_path', [arguments...,'pipe:1']);
  var bound = false;
  ffmpeg.on('data', function(){
   if (!bound){
    if (aitunes) airtunes.reset();
    ffmpeg.stdout.pipe(airtunes, { end: false });
   }
   bound = true;
  });
});
```
@Laurent
Thank you for your help to narrow down and fix this issue.