### PR TITLE
Adds Bose SoundTouch under supported devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Node-airtunes was tested on the following devices:
 * Apple TV
 * Zeppelin Air
 * Raspberry PI
+* Bose SoundTouch
 
 Ping me to add more devices to this list.
 


### PR DESCRIPTION
I have tested the module with a [Bose SoundTouch](http://www.bose.co.uk/GB/en/home-and-personal-audio/wi-fi-music-systems/soundtouch-wi-fi-music-systems/) device and it works great.

Thank you for creating such a useful and easy to use node module for Airtunes!